### PR TITLE
Fix Jenkins readiness verification script

### DIFF
--- a/continuous-integration/step1-verify.sh
+++ b/continuous-integration/step1-verify.sh
@@ -1,3 +1,10 @@
-#!/bin/bash 
+#!/bin/bash
 
-#[ -f /tmp/jenkins_ready ] && echo "done"
+# Verify that Jenkins has finished starting up by checking for the
+# presence of a marker file created by the setup process. When the file
+# exists the script prints "done" so the scenario framework knows it can
+# proceed to the next step.
+if [ -f /tmp/jenkins_ready ]; then
+  echo "done"
+fi
+


### PR DESCRIPTION
## Summary
- restore Jenkins startup check in step1-verify.sh
- add documentation and clearer conditional to report readiness

## Testing
- `bash continuous-integration/step1-verify.sh`
- `touch /tmp/jenkins_ready && bash continuous-integration/step1-verify.sh`
- `bash -n continuous-integration/step1-verify.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a0af4436fc832dbce1e8efd11fa996